### PR TITLE
Added language support for Forestry scoops

### DIFF
--- a/resources/assets/wailaharvestability/lang/en_US.lang
+++ b/resources/assets/wailaharvestability/lang/en_US.lang
@@ -3,6 +3,7 @@ wailaharvestability.toolclass.pickaxe=Pickaxe
 wailaharvestability.toolclass.shovel=Shovel
 wailaharvestability.toolclass.axe=Axe
 wailaharvestability.toolclass.chisel=Chisel
+wailaharvestability.toolclass.scoop=Scoop
 
 # tooltips
 wailaharvestability.effectivetool=Effective Tool : 


### PR DESCRIPTION
Fixes unlocalized names showing when looking at beehives, as they require an unusual tool class (scoop).
