### PR TITLE
[Feature] Added names instead of numbers for harvestlevels

### DIFF
--- a/java/squeek/wailaharvestability/TooltipHandler.java
+++ b/java/squeek/wailaharvestability/TooltipHandler.java
@@ -16,7 +16,9 @@ public class TooltipHandler {
     public void tooltipEvent(ItemTooltipEvent event) {
         Item item = event.getItemStack().getItem();
         if (item instanceof ItemTool && Config.HARVEST_LEVEL_TOOLTIP) {
-            event.getToolTip().add(I18n.format("wailaharvestability.harvestlevel") + StringHelper.getHarvestLevelName(((ItemTool) item).getToolMaterial().getHarvestLevel()));
+            int harvestLevel = ((ItemTool) item).getToolMaterial().getHarvestLevel();
+            String harvestName = StringHelper.getHarvestLevelName(harvestLevel);
+            event.getToolTip().add(I18n.format("wailaharvestability.harvestlevel") + harvestName);
         }
     }
 }

--- a/java/squeek/wailaharvestability/TooltipHandler.java
+++ b/java/squeek/wailaharvestability/TooltipHandler.java
@@ -5,13 +5,11 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemPickaxe;
 import net.minecraft.item.ItemTool;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
-import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class TooltipHandler {
-    private static String[] modsSupported = new String[]{"tconstruct", "taiga"};
 
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
@@ -23,15 +21,8 @@ public class TooltipHandler {
     }
 
     private String getHarvastName(int level) {
-        if (I18n.hasKey("wailaharvestability.harvestlevel." + level)) {
+        if(I18n.hasKey("wailaharvestability.harvestlevel." + level)) {
             return I18n.format("wailaharvestability.harvestlevel." + level);
-        }
-        for (String mod : modsSupported) {
-            if (Loader.isModLoaded(mod)) {
-                if (I18n.hasKey("wailaharvestability.harvestlevel." + level + "." + mod)) {
-                    return I18n.format("wailaharvestability.harvestlevel." + level + "." + mod);
-                }
-            }
         }
         return Integer.toString(level);
     }

--- a/java/squeek/wailaharvestability/TooltipHandler.java
+++ b/java/squeek/wailaharvestability/TooltipHandler.java
@@ -8,6 +8,7 @@ import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import squeek.wailaharvestability.helpers.StringHelper;
 
 public class TooltipHandler {
     @SubscribeEvent
@@ -15,7 +16,7 @@ public class TooltipHandler {
     public void tooltipEvent(ItemTooltipEvent event) {
         Item item = event.getItemStack().getItem();
         if (item instanceof ItemTool && Config.HARVEST_LEVEL_TOOLTIP) {
-            event.getToolTip().add(I18n.format("wailaharvestability.harvestlevel") + ((ItemTool) item).getToolMaterial().getHarvestLevel());
+            event.getToolTip().add(I18n.format("wailaharvestability.harvestlevel") + StringHelper.getHarvestLevelName(((ItemTool) item).getToolMaterial().getHarvestLevel()));
         }
     }
 }

--- a/java/squeek/wailaharvestability/TooltipHandler.java
+++ b/java/squeek/wailaharvestability/TooltipHandler.java
@@ -10,20 +10,12 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class TooltipHandler {
-
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
     public void tooltipEvent(ItemTooltipEvent event) {
         Item item = event.getItemStack().getItem();
         if (item instanceof ItemTool && Config.HARVEST_LEVEL_TOOLTIP) {
-            event.getToolTip().add(I18n.format("wailaharvestability.harvestlevel") + getHarvastName(((ItemTool) item).getToolMaterial().getHarvestLevel()));
+            event.getToolTip().add(I18n.format("wailaharvestability.harvestlevel") + ((ItemTool) item).getToolMaterial().getHarvestLevel());
         }
-    }
-
-    private String getHarvastName(int level) {
-        if(I18n.hasKey("wailaharvestability.harvestlevel." + level)) {
-            return I18n.format("wailaharvestability.harvestlevel." + level);
-        }
-        return Integer.toString(level);
     }
 }

--- a/java/squeek/wailaharvestability/TooltipHandler.java
+++ b/java/squeek/wailaharvestability/TooltipHandler.java
@@ -10,12 +10,20 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class TooltipHandler {
+
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
     public void tooltipEvent(ItemTooltipEvent event) {
         Item item = event.getItemStack().getItem();
         if (item instanceof ItemTool && Config.HARVEST_LEVEL_TOOLTIP) {
-            event.getToolTip().add(I18n.format("wailaharvestability.harvestlevel") + ((ItemTool) item).getToolMaterial().getHarvestLevel());
+            event.getToolTip().add(I18n.format("wailaharvestability.harvestlevel") + getHarvastName(((ItemTool) item).getToolMaterial().getHarvestLevel()));
         }
+    }
+
+    private String getHarvastName(int level) {
+        if(I18n.hasKey("wailaharvestability.harvestlevel." + level)) {
+            return I18n.format("wailaharvestability.harvestlevel." + level);
+        }
+        return Integer.toString(level);
     }
 }

--- a/java/squeek/wailaharvestability/TooltipHandler.java
+++ b/java/squeek/wailaharvestability/TooltipHandler.java
@@ -5,11 +5,13 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemPickaxe;
 import net.minecraft.item.ItemTool;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class TooltipHandler {
+    private static String[] modsSupported = new String[]{"tconstruct", "taiga"};
 
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
@@ -21,8 +23,15 @@ public class TooltipHandler {
     }
 
     private String getHarvastName(int level) {
-        if(I18n.hasKey("wailaharvestability.harvestlevel." + level)) {
+        if (I18n.hasKey("wailaharvestability.harvestlevel." + level)) {
             return I18n.format("wailaharvestability.harvestlevel." + level);
+        }
+        for (String mod : modsSupported) {
+            if (Loader.isModLoaded(mod)) {
+                if (I18n.hasKey("wailaharvestability.harvestlevel." + level + "." + mod)) {
+                    return I18n.format("wailaharvestability.harvestlevel." + level + "." + mod);
+                }
+            }
         }
         return Integer.toString(level);
     }

--- a/java/squeek/wailaharvestability/helpers/StringHelper.java
+++ b/java/squeek/wailaharvestability/helpers/StringHelper.java
@@ -15,7 +15,7 @@ public class StringHelper
 	{
 		try
 		{
-			HarvestLevels = Class.forName("tconstruct.library.util.HarvestLevels");
+			HarvestLevels = Class.forName("slimeknights.tconstruct.library.utils");
 			getHarvestLevelName = HarvestLevels.getDeclaredMethod("getHarvestLevelName", int.class);
 		}
 		catch (Exception e)

--- a/java/squeek/wailaharvestability/helpers/StringHelper.java
+++ b/java/squeek/wailaharvestability/helpers/StringHelper.java
@@ -15,7 +15,7 @@ public class StringHelper
 	{
 		try
 		{
-			HarvestLevels = Class.forName("slimeknights.tconstruct.library.utils");
+			HarvestLevels = Class.forName("slimeknights.tconstruct.library.utils.HarvestLevels");
 			getHarvestLevelName = HarvestLevels.getDeclaredMethod("getHarvestLevelName", int.class);
 		}
 		catch (Exception e)

--- a/resources/assets/wailaharvestability/lang/en_US.lang
+++ b/resources/assets/wailaharvestability/lang/en_US.lang
@@ -30,3 +30,9 @@ option.harvestability.silktouchability=Silk Touchability
 option.harvestability.silktouchability.sneakingonly=Sneak only: Silk Touchability
 option.harvestability.harvestlevelnum=Harvest level no.
 option.harvestability.harvestlevelnum.sneakingonly=Sneak only: Harvest level no.
+
+# harvestlevels
+wailaharvestability.harvestlevel0=Wood
+wailaharvestability.harvestlevel1=Stone
+wailaharvestability.harvestlevel2=Iron
+wailaharvestability.harvestlevel3=Diamond

--- a/resources/assets/wailaharvestability/lang/en_US.lang
+++ b/resources/assets/wailaharvestability/lang/en_US.lang
@@ -17,12 +17,12 @@ wailaharvestability.harvestlevel.1=Stone
 wailaharvestability.harvestlevel.2=Iron
 wailaharvestability.harvestlevel.3=Diamond
 # tinkers construct
-wailaharvestability.harvestlevel.4=Cobalt
+wailaharvestability.harvestlevel.4.tconstruct=Cobalt
 # tinkers alloying addon
-wailaharvestability.harvestlevel.5=Titanite
-wailaharvestability.harvestlevel.6=Meteorite
-wailaharvestability.harvestlevel.7=Vibranium
-wailaharvestability.harvestlevel.8=Adamantite
+wailaharvestability.harvestlevel.5.taiga=Titanite
+wailaharvestability.harvestlevel.6.taiga=Meteorite
+wailaharvestability.harvestlevel.7.taiga=Vibranium
+wailaharvestability.harvestlevel.8.taiga=Adamantite
 
 # options
 option.harvestability.harvestlevel=Harvest level

--- a/resources/assets/wailaharvestability/lang/en_US.lang
+++ b/resources/assets/wailaharvestability/lang/en_US.lang
@@ -9,7 +9,7 @@ wailaharvestability.toolclass.sword=Sword
 
 # tooltips
 wailaharvestability.effectivetool=Effective Tool : 
-wailaharvestability.harvestlevel=Harvest Level :
+wailaharvestability.harvestlevel=Harvest Level : 
 wailaharvestability.currentlyharvestable= Currently Harvestable
 wailaharvestability.harvestable= Harvestable
 # vanilla

--- a/resources/assets/wailaharvestability/lang/en_US.lang
+++ b/resources/assets/wailaharvestability/lang/en_US.lang
@@ -17,12 +17,12 @@ wailaharvestability.harvestlevel.1=Stone
 wailaharvestability.harvestlevel.2=Iron
 wailaharvestability.harvestlevel.3=Diamond
 # tinkers construct
-wailaharvestability.harvestlevel.4.tconstruct=Cobalt
+wailaharvestability.harvestlevel.4=Cobalt
 # tinkers alloying addon
-wailaharvestability.harvestlevel.5.taiga=Titanite
-wailaharvestability.harvestlevel.6.taiga=Meteorite
-wailaharvestability.harvestlevel.7.taiga=Vibranium
-wailaharvestability.harvestlevel.8.taiga=Adamantite
+wailaharvestability.harvestlevel.5=Titanite
+wailaharvestability.harvestlevel.6=Meteorite
+wailaharvestability.harvestlevel.7=Vibranium
+wailaharvestability.harvestlevel.8=Adamantite
 
 # options
 option.harvestability.harvestlevel=Harvest level

--- a/resources/assets/wailaharvestability/lang/en_US.lang
+++ b/resources/assets/wailaharvestability/lang/en_US.lang
@@ -9,7 +9,7 @@ wailaharvestability.toolclass.sword=Sword
 
 # tooltips
 wailaharvestability.effectivetool=Effective Tool : 
-wailaharvestability.harvestlevel=Harvest Level : 
+wailaharvestability.harvestlevel=Harvest Level :
 wailaharvestability.currentlyharvestable= Currently Harvestable
 wailaharvestability.harvestable= Harvestable
 # vanilla

--- a/resources/assets/wailaharvestability/lang/en_US.lang
+++ b/resources/assets/wailaharvestability/lang/en_US.lang
@@ -9,20 +9,9 @@ wailaharvestability.toolclass.sword=Sword
 
 # tooltips
 wailaharvestability.effectivetool=Effective Tool : 
-wailaharvestability.harvestlevel=Harvest Level :
+wailaharvestability.harvestlevel=Harvest Level : 
 wailaharvestability.currentlyharvestable= Currently Harvestable
 wailaharvestability.harvestable= Harvestable
-# vanilla
-wailaharvestability.harvestlevel.1=Stone
-wailaharvestability.harvestlevel.2=Iron
-wailaharvestability.harvestlevel.3=Diamond
-# tinkers construct
-wailaharvestability.harvestlevel.4=Cobalt
-# tinkers alloying addon
-wailaharvestability.harvestlevel.5=Titanite
-wailaharvestability.harvestlevel.6=Meteorite
-wailaharvestability.harvestlevel.7=Vibranium
-wailaharvestability.harvestlevel.8=Adamantite
 
 # options
 option.harvestability.harvestlevel=Harvest level

--- a/resources/assets/wailaharvestability/lang/en_US.lang
+++ b/resources/assets/wailaharvestability/lang/en_US.lang
@@ -30,9 +30,3 @@ option.harvestability.silktouchability=Silk Touchability
 option.harvestability.silktouchability.sneakingonly=Sneak only: Silk Touchability
 option.harvestability.harvestlevelnum=Harvest level no.
 option.harvestability.harvestlevelnum.sneakingonly=Sneak only: Harvest level no.
-
-# harvestlevels
-wailaharvestability.harvestlevel0=Wood
-wailaharvestability.harvestlevel1=Stone
-wailaharvestability.harvestlevel2=Iron
-wailaharvestability.harvestlevel3=Diamond

--- a/resources/assets/wailaharvestability/lang/en_US.lang
+++ b/resources/assets/wailaharvestability/lang/en_US.lang
@@ -9,9 +9,20 @@ wailaharvestability.toolclass.sword=Sword
 
 # tooltips
 wailaharvestability.effectivetool=Effective Tool : 
-wailaharvestability.harvestlevel=Harvest Level : 
+wailaharvestability.harvestlevel=Harvest Level :
 wailaharvestability.currentlyharvestable= Currently Harvestable
 wailaharvestability.harvestable= Harvestable
+# vanilla
+wailaharvestability.harvestlevel.1=Stone
+wailaharvestability.harvestlevel.2=Iron
+wailaharvestability.harvestlevel.3=Diamond
+# tinkers construct
+wailaharvestability.harvestlevel.4=Cobalt
+# tinkers alloying addon
+wailaharvestability.harvestlevel.5=Titanite
+wailaharvestability.harvestlevel.6=Meteorite
+wailaharvestability.harvestlevel.7=Vibranium
+wailaharvestability.harvestlevel.8=Adamantite
 
 # options
 option.harvestability.harvestlevel=Harvest level


### PR DESCRIPTION
So, many of my modpack users are requesting this, because i use the mod TAIGA and numbers for harvesting stuff are not that helpful
I'm not in any way a forge modder, but looked into your code and made a small add on so it can use multiple mods for multiple harvest levels

I KNOW it's not the best / nicest way of doing this, but it will not break in updates and doesn't need additional API's

So i choose for this way of adding names, 
all responsibility at this mod side and made this easy addon.
It's probably not the final way of handeling this. but at least a temporary fix now

I'm all open for feedback in any way
